### PR TITLE
Sidebar Dashboard item fix, task name validation

### DIFF
--- a/backend/app/Http/Controllers/TaskController.php
+++ b/backend/app/Http/Controllers/TaskController.php
@@ -90,7 +90,7 @@ class TaskController extends Controller
         }
 
         $this->validate($request, [
-            'title' => 'required|string|max:100',
+            'title' => 'required|string|max:100|regex:/^[0-9a-zA-Z]/',
             'description' => 'nullable|string',
             'due_date' => 'nullable|date',
             'column_id' => [

--- a/frontend/src/components/Board/Board.js
+++ b/frontend/src/components/Board/Board.js
@@ -1263,6 +1263,12 @@ const Board = () => {
     const handleTaskNameConfirm = async (name) => {
         handleTaskNameCancel();
         try {
+            if (!/^[0-9a-zA-Z]/.test(name)) {
+                setError({
+                    message: "The task can only start with a number, or a letter!"
+                });
+                return;
+            }
             const newTask = {
                 column_id: board.columns[currentDivIndex].column_id,
                 title: name,

--- a/frontend/src/components/Navigation/SideBar.js
+++ b/frontend/src/components/Navigation/SideBar.js
@@ -40,7 +40,7 @@ const Sidebar = () => {
                     <li className={location.pathname === '/dashboard' || isBoardActive ? 'active' : ''}>
                         <Link to='/dashboard'>
                             {homeIcon}
-                            <span>Dashboard</span>
+                            <span>Board</span>
                         </Link>
                     </li>
 


### PR DESCRIPTION
# Elkészített kártyák
- Sidebar-on dashboard átnevezése board-ra megtévesztő design miatt
- Task neve nem kezdődhet csak betűvel vagy számmal
> **Megjegyzés:** Task név ellenőrzés frontenden és backenden is történik, ennek az oka az, hogy optimálisabb, ha frontenden előre ellenőrzünk, és ha sikertelen, nem is küldjük el a kérést. Így nyílván kétszer is átesik ugyanazon az ellenőrzésen, viszont a felhasználónak így is gyorsabbnak tűnik, mintha a backenden történne csak.